### PR TITLE
Long code support

### DIFF
--- a/lib/afterbanks/base.rb
+++ b/lib/afterbanks/base.rb
@@ -85,10 +85,15 @@ module Afterbanks
       return unless response_body.is_a?(Hash)
 
       code = response_body['code']
+      long_code = response_body['longCode']
       message = response_body['message']
       additional_info = response_body['additional_info']
 
       error_info = { message: message, debug_id: debug_id }
+
+      if !long_code.nil?
+        error_info[:long_code] = long_code
+      end
 
       case code
       when 1

--- a/lib/afterbanks/error.rb
+++ b/lib/afterbanks/error.rb
@@ -1,10 +1,11 @@
 module Afterbanks
   class Error < ::StandardError
-    attr_reader :message, :debug_id, :additional_info
+    attr_reader :message, :debug_id, :long_code, :additional_info
 
-    def initialize(message:, debug_id:, additional_info: nil)
+    def initialize(message:, debug_id:, long_code: nil, additional_info: nil)
       @message = message
       @debug_id = debug_id
+      @long_code = long_code
       @additional_info = additional_info
     end
 

--- a/spec/afterbanks/resources/account_spec.rb
+++ b/spec/afterbanks/resources/account_spec.rb
@@ -290,8 +290,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::ConnectionDataError)
               .and having_attributes(
-                code:    3,
-                message: "Datos de la conexión inválidos"
+                code:      3,
+                long_code: 3000,
+                message:   "Datos de la conexión inválidos"
               )
           )
         end
@@ -356,8 +357,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::HumanActionNeededError)
               .and having_attributes(
-                code:    6,
-                message: "El usuario debe realizar una acción en el banco"
+                code:      6,
+                long_code: 6001,
+                message:   "El usuario debe realizar una acción en el banco"
               )
           )
         end
@@ -380,6 +382,7 @@ describe Afterbanks::Account do
               an_instance_of(Afterbanks::TwoStepAuthenticationError)
                 .and having_attributes(
                   code:            50,
+                  long_code:       50002,
                   message:         "A bank te ha enviado un código",
                   debug_id:        'debugerror50tsa',
                   additional_info: {
@@ -407,6 +410,7 @@ describe Afterbanks::Account do
               an_instance_of(Afterbanks::AccountIdNeededError)
                 .and having_attributes(
                   code:            50,
+                  long_code:       50001,
                   message:         "Escoge una cuenta",
                   debug_id:        'debugerror50accid',
                   additional_info: [

--- a/spec/afterbanks/resources/account_spec.rb
+++ b/spec/afterbanks/resources/account_spec.rb
@@ -246,8 +246,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::GenericError)
               .and having_attributes(
-                code:    1,
-                message: "Error genérico"
+                code:     1,
+                message:  "Error genérico",
+                debug_id: 'debugerror1'
               )
           )
         end
@@ -268,8 +269,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::ServiceUnavailableTemporarilyError)
               .and having_attributes(
-                code:    2,
-                message: "Servicio no disponible ahora mismo"
+                code:     2,
+                message:  "Servicio no disponible ahora mismo",
+                debug_id: 'debugerror2'
               )
           )
         end
@@ -292,7 +294,8 @@ describe Afterbanks::Account do
               .and having_attributes(
                 code:      3,
                 long_code: 3000,
-                message:   "Datos de la conexión inválidos"
+                message:   "Datos de la conexión inválidos",
+                debug_id:  'debugerror3'
               )
           )
         end
@@ -313,8 +316,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::AccountIdDoesNotExistError)
               .and having_attributes(
-                code:    4,
-                message: "AccountID no existe"
+                code:     4,
+                message:  "AccountID no existe",
+                debug_id: 'debugerror4'
               )
           )
         end
@@ -335,8 +339,9 @@ describe Afterbanks::Account do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::CutConnectionError)
               .and having_attributes(
-                code:    5,
-                message: "Conexión cortada"
+                code:     5,
+                message:  "Conexión cortada",
+                debug_id: 'debugerror5'
               )
           )
         end
@@ -359,7 +364,8 @@ describe Afterbanks::Account do
               .and having_attributes(
                 code:      6,
                 long_code: 6001,
-                message:   "El usuario debe realizar una acción en el banco"
+                message:   "El usuario debe realizar una acción en el banco",
+                debug_id:  'debugerror6'
               )
           )
         end

--- a/spec/afterbanks/resources/transaction_spec.rb
+++ b/spec/afterbanks/resources/transaction_spec.rb
@@ -317,9 +317,10 @@ describe Afterbanks::Transaction do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::ConnectionDataError)
               .and having_attributes(
-                code:     3,
-                message:  "Datos de la conexión inválidos",
-                debug_id: 'debugerror3'
+                code:      3,
+                long_code: 3000,
+                message:   "Datos de la conexión inválidos",
+                debug_id:  'debugerror3'
               )
           )
         end
@@ -386,9 +387,10 @@ describe Afterbanks::Transaction do
           expect { api_call }.to raise_error(
             an_instance_of(Afterbanks::HumanActionNeededError)
               .and having_attributes(
-                code:     6,
-                message:  "El usuario debe realizar una acción en el banco",
-                debug_id: 'debugerror6'
+                code:      6,
+                long_code: 6001,
+                message:   "El usuario debe realizar una acción en el banco",
+                debug_id:  'debugerror6'
               )
           )
         end
@@ -411,6 +413,7 @@ describe Afterbanks::Transaction do
               an_instance_of(Afterbanks::TwoStepAuthenticationError)
                 .and having_attributes(
                   code:            50,
+                  long_code:       50002,
                   message:         "A bank te ha enviado un código",
                   debug_id:        'debugerror50tsa',
                   additional_info: {
@@ -438,6 +441,7 @@ describe Afterbanks::Transaction do
               an_instance_of(Afterbanks::AccountIdNeededError)
                 .and having_attributes(
                   code:            50,
+                  long_code:       50001,
                   message:         "Escoge una cuenta",
                   debug_id:        'debugerror50accid',
                   additional_info: [

--- a/spec/responses/common/error_3.json
+++ b/spec/responses/common/error_3.json
@@ -1,4 +1,5 @@
 {
   "message": "Datos de la conexión inválidos",
-  "code": 3
+  "code": 3,
+  "longCode": 3000
 }

--- a/spec/responses/common/error_50_account_id.json
+++ b/spec/responses/common/error_50_account_id.json
@@ -1,6 +1,7 @@
 {
   "message": "Escoge una cuenta",
   "code": 50,
+  "longCode": 50001,
   "additional_info": [
     {
       "account_id": 0,

--- a/spec/responses/common/error_50_two_way_authentication.json
+++ b/spec/responses/common/error_50_two_way_authentication.json
@@ -1,6 +1,7 @@
 {
   "message": "A bank te ha enviado un código",
   "code": 50,
+  "longCode": 50002,
   "additional_info": {
     "session_id": "12345678",
     "counterId": 4

--- a/spec/responses/common/error_6.json
+++ b/spec/responses/common/error_6.json
@@ -1,4 +1,5 @@
 {
   "message": "El usuario debe realizar una acción en el banco",
-  "code": 6
+  "code": 6,
+  "longCode": 6001
 }


### PR DESCRIPTION
Return the `longCode` in any `Afterbanks:Error`, as documented in [the official docs](https://app.swaggerhub.com/apis/Afterbanks/afterbanks-api-extendida/5.8.1#/Error)